### PR TITLE
Fix an error for `Workit/RestrictOnSend` when not in class

### DIFF
--- a/lib/rubocop/cop/workit/restrict_on_send.rb
+++ b/lib/rubocop/cop/workit/restrict_on_send.rb
@@ -30,12 +30,14 @@ module RuboCop
 
         def on_def(node)
           return unless NEED_RESTRICT_ON_SEND.include?(node.method_name)
+          return unless (class_node = class_node(node))
 
-          class_node = class_node(node)
           add_offense(class_node) unless defined_restrict_on_send?(class_node)
         end
 
         def class_node(node)
+          return if node.parent.nil?
+
           if node.parent.class_type?
             node.parent
           else

--- a/spec/rubocop/cop/workit/restrict_on_send_spec.rb
+++ b/spec/rubocop/cop/workit/restrict_on_send_spec.rb
@@ -24,6 +24,24 @@ RSpec.describe RuboCop::Cop::Workit::RestrictOnSend, :config do
     RUBY
   end
 
+  it "does not register an offense when not in class" do
+    expect_no_offenses(<<~RUBY)
+      def on_send(node)
+        # ...
+      end
+    RUBY
+  end
+
+  it "does not register an offense when module" do
+    expect_no_offenses(<<~RUBY)
+      module FooCop
+        def on_send(node)
+          # ...
+        end
+      end
+    RUBY
+  end
+
   it "does not register an offense when using `RESTRICT_ON_SEND` and defines `on_send`" do
     expect_no_offenses(<<~RUBY)
       class FooCop


### PR DESCRIPTION
This PR is fix an error for `Workit/RestrictOnSend` when not in class.

```ruby
def on_send(node)
  # ...
end
```