### PR TITLE
Add new `Workit/RSpecCapybaraPredicateMatcher` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,7 @@ Style/StringLiteralsInInterpolation:
 
 RSpec/ExampleLength:
   Enabled: false
+
+RSpec/FilePath:
+  Exclude:
+    - spec/rubocop/cop/workit/rspec*.rb

--- a/config/default.yml
+++ b/config/default.yml
@@ -30,3 +30,13 @@ Workit/RestrictOnSend:
   Description: |
     Check for `RESTRICT_ON_SEND` is defined if `on_send` or `after_send` are defined.
   Enabled: false
+
+Workit/RSpecCapybaraPredicateMatcher:
+  Description: Prefer using predicate matcher over using predicate method directly.
+  Enabled: false
+  Strict: true
+  EnforcedStyle: inflected
+  AllowedExplicitMatchers: []
+  SupportedStyles:
+    - inflected
+    - explicit

--- a/lib/rubocop/cop/workit/mixin/rspec_explicit_help.rb
+++ b/lib/rubocop/cop/workit/mixin/rspec_explicit_help.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Workit
+      # A helper for `explicit` style
+      module RSpecExplicitHelp
+        include RuboCop::RSpec::Language
+        extend NodePattern::Macros
+
+        MSG_EXPLICIT = "Prefer using `%<predicate_name>s` over " \
+                       "`%<matcher_name>s` matcher."
+        BUILT_IN_MATCHERS = %w[
+          be_truthy be_falsey be_falsy
+          have_attributes have_received
+          be_between be_within
+        ].freeze
+
+        private
+
+        def allowed_explicit_matchers
+          cop_config.fetch("AllowedExplicitMatchers", []) + BUILT_IN_MATCHERS
+        end
+
+        def check_explicit(node)
+          predicate_matcher_block?(node) do |actual, matcher|
+            add_offense(node, message: message_explicit(matcher)) do |corrector|
+              to_node = node.send_node
+              corrector_explicit(corrector, to_node, actual, matcher, to_node)
+            end
+            ignore_node(node.children.first)
+            return
+          end
+
+          return if part_of_ignored_node?(node)
+
+          predicate_matcher?(node) do |actual, matcher|
+            add_offense(node, message: message_explicit(matcher)) do |corrector|
+              corrector_explicit(corrector, node, actual, matcher, matcher)
+            end
+          end
+        end
+
+        # @!method predicate_matcher?(node)
+        def_node_matcher :predicate_matcher?, <<-PATTERN
+          (send
+            (send nil? :expect $!nil?)
+            #Runners.all
+            {$(send nil? #predicate_matcher_name? ...)
+              (block $(send nil? #predicate_matcher_name? ...) ...)})
+        PATTERN
+
+        # @!method predicate_matcher_block?(node)
+        def_node_matcher :predicate_matcher_block?, <<-PATTERN
+          (block
+            (send
+              (send nil? :expect $!nil?)
+              #Runners.all
+              $(send nil? #predicate_matcher_name?))
+            ...)
+        PATTERN
+
+        def predicate_matcher_name?(name)
+          raise ::NotImplementedError
+        end
+
+        def message_explicit(matcher)
+          format(MSG_EXPLICIT,
+                 predicate_name: to_predicate_method(matcher.method_name),
+                 matcher_name: matcher.method_name)
+        end
+
+        def corrector_explicit(corrector, to_node, actual, matcher, block_child)
+          replacement_matcher = replacement_matcher(to_node)
+          corrector.replace(matcher.loc.expression, replacement_matcher)
+          move_predicate(corrector, actual, matcher, block_child)
+          corrector.replace(to_node.loc.selector, "to")
+        end
+
+        def move_predicate(corrector, actual, matcher, block_child)
+          predicate = to_predicate_method(matcher.method_name)
+          args = args_loc(matcher).source
+          block_loc = block_loc(block_child)
+          block = block_loc ? block_loc.source : ""
+
+          corrector.remove(block_loc) if block_loc
+          corrector.insert_after(actual.loc.expression,
+                                 ".#{predicate}" + args + block)
+        end
+
+        def to_predicate_method(matcher)
+          raise ::NotImplementedError
+        end
+
+        def replacement_matcher(node)
+          case [cop_config["Strict"], node.method?(:to)]
+          when [true, true]
+            "be(true)"
+          when [true, false]
+            "be(false)"
+          when [false, true]
+            "be_truthy"
+          when [false, false]
+            "be_falsey"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/workit/mixin/rspec_inflected_help.rb
+++ b/lib/rubocop/cop/workit/mixin/rspec_inflected_help.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Workit
+      # A helper for `inflected` style
+      module RSpecInflectedHelp
+        include RuboCop::RSpec::Language
+        extend NodePattern::Macros
+
+        MSG_INFLECTED = "Prefer using `%<matcher_name>s` matcher over " \
+                        "`%<predicate_name>s`."
+
+        private
+
+        def check_inflected(node)
+          predicate_in_actual?(node) do |predicate, to, matcher|
+            msg = message_inflected(predicate)
+            add_offense(node, message: msg) do |corrector|
+              remove_predicate(corrector, predicate)
+              corrector.replace(node.loc.selector,
+                                true?(to, matcher) ? "to" : "not_to")
+              rewrite_matcher(corrector, predicate, matcher)
+            end
+          end
+        end
+
+        # @!method predicate_in_actual?(node)
+        def_node_matcher :predicate_in_actual?, <<-PATTERN
+          (send
+            (send nil? :expect {
+              (block $(send !nil? #predicate? ...) ...)
+              $(send !nil? #predicate? ...)})
+            $#Runners.all
+            $#boolean_matcher?)
+        PATTERN
+
+        # @!method be_bool?(node)
+        def_node_matcher :be_bool?, <<-PATTERN
+          (send nil? {:be :eq :eql :equal} {true false})
+        PATTERN
+
+        # @!method be_boolthy?(node)
+        def_node_matcher :be_boolthy?, <<-PATTERN
+          (send nil? {:be_truthy :be_falsey :be_falsy :a_truthy_value :a_falsey_value :a_falsy_value})
+        PATTERN
+
+        def boolean_matcher?(node)
+          if cop_config["Strict"]
+            be_boolthy?(node)
+          else
+            be_bool?(node) || be_boolthy?(node)
+          end
+        end
+
+        def predicate?(sym)
+          raise ::NotImplementedError
+        end
+
+        def message_inflected(predicate)
+          format(MSG_INFLECTED,
+                 predicate_name: predicate.method_name,
+                 matcher_name: to_predicate_matcher(predicate.method_name))
+        end
+
+        def to_predicate_matcher(name)
+          raise ::NotImplementedError
+        end
+
+        def remove_predicate(corrector, predicate)
+          range = predicate.loc.dot.with(
+            end_pos: predicate.loc.expression.end_pos
+          )
+
+          corrector.remove(range)
+
+          block_range = block_loc(predicate)
+          corrector.remove(block_range) if block_range
+        end
+
+        def rewrite_matcher(corrector, predicate, matcher)
+          args = args_loc(predicate).source
+          block_loc = block_loc(predicate)
+          block = block_loc ? block_loc.source : ""
+
+          corrector.replace(
+            matcher.loc.expression,
+            to_predicate_matcher(predicate.method_name) + args + block
+          )
+        end
+
+        def true?(to_symbol, matcher)
+          result = case matcher.method_name
+                   when :be, :eq
+                     matcher.first_argument.true_type?
+                   when :be_truthy, :a_truthy_value
+                     true
+                   when :be_falsey, :be_falsy, :a_falsey_value, :a_falsy_value
+                     false
+                   end
+          to_symbol == :to ? result : !result
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/workit/mixin/rspec_predicate_matcher_base.rb
+++ b/lib/rubocop/cop/workit/mixin/rspec_predicate_matcher_base.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Workit
+      # Helper methods for Predicate matcher.
+      module RSpecPredicateMatcherBase
+        include ConfigurableEnforcedStyle
+        include RSpecInflectedHelp
+        include RSpecExplicitHelp
+
+        RESTRICT_ON_SEND = %i[to to_not not_to].freeze
+
+        def on_send(node)
+          case style
+          when :inflected
+            check_inflected(node)
+          when :explicit
+            check_explicit(node)
+          end
+        end
+
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+          check_explicit(node) if style == :explicit
+        end
+
+        private
+
+        # returns args location with whitespace
+        # @example
+        #   foo 1, 2
+        #      ^^^^^
+        def args_loc(send_node)
+          send_node.loc.selector.end.with(
+            end_pos: send_node.loc.expression.end_pos
+          )
+        end
+
+        # returns block location with whitespace
+        # @example
+        #   foo { bar }
+        #      ^^^^^^^^
+        def block_loc(send_node)
+          parent = send_node.parent
+          return unless parent.block_type?
+
+          send_node.loc.expression.end.with(
+            end_pos: parent.loc.expression.end_pos
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/workit/rspec_capybara_predicate_matcher.rb
+++ b/lib/rubocop/cop/workit/rspec_capybara_predicate_matcher.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Workit
+      # Prefer using predicate matcher over using predicate method directly.
+      #
+      # Capybara defines magic matchers for predicate methods.
+      # This cop recommends to use the predicate matcher instead of using
+      # predicate method directly.
+      #
+      # @example Strict: true, EnforcedStyle: inflected (default)
+      #   # bad
+      #   expect(foo.matches_css?(bar: 'baz')).to be_truthy
+      #   expect(foo.matches_selector?(bar: 'baz')).to be_truthy
+      #   expect(foo.matches_style?(bar: 'baz')).to be_truthy
+      #   expect(foo.matches_xpath?(bar: 'baz')).to be_truthy
+      #
+      #   # good
+      #   expect(foo).to match_css(bar: 'baz')
+      #   expect(foo).to match_selector(bar: 'baz')
+      #   expect(foo).to match_style(bar: 'baz')
+      #   expect(foo).to match_xpath(bar: 'baz')
+      #
+      #   # also good - It checks "true" strictly.
+      #   expect(foo.matches_style?(bar: 'baz')).to be(true)
+      #
+      # @example Strict: false, EnforcedStyle: inflected
+      #   # bad
+      #   expect(foo.matches_style?(bar: 'baz')).to be_truthy
+      #   expect(foo.matches_style?(bar: 'baz')).to be(true)
+      #
+      #   # good
+      #   expect(foo).to match_style(bar: 'baz')
+      #
+      # @example Strict: true, EnforcedStyle: explicit
+      #   # bad
+      #   expect(foo).to match_style(bar: 'baz')
+      #
+      #   # good - the above code is rewritten to it by this cop
+      #   expect(foo.matches_style?(bar: 'baz')).to be(true)
+      #
+      # @example Strict: false, EnforcedStyle: explicit
+      #   # bad
+      #   expect(foo).to match_style(bar: 'baz')
+      #
+      #   # good - the above code is rewritten to it by this cop
+      #   expect(foo.matches_style?(bar: 'baz')).to be_truthy
+      #
+      class RSpecCapybaraPredicateMatcher < Base
+        extend AutoCorrector
+        include RuboCop::Cop::Workit::RSpecPredicateMatcherBase
+
+        MATCHER_SUFFIX = %w[css selector style xpath].freeze
+        INFLECTED_MATCHER = MATCHER_SUFFIX.each.map do |suffix|
+          "match_#{suffix}"
+        end.freeze
+        EXPLICIT_MATCHER = MATCHER_SUFFIX.each.map do |suffix|
+          "matches_#{suffix}?"
+        end.freeze
+
+        def predicate_matcher_name?(name)
+          name = name.to_s
+          return false if allowed_explicit_matchers.include?(name)
+
+          INFLECTED_MATCHER.include?(name)
+        end
+
+        def to_predicate_matcher(name)
+          name.to_s.sub("matches_", "match_")[0..-2]
+        end
+
+        def predicate?(sym)
+          EXPLICIT_MATCHER.include?(sym.to_s)
+        end
+
+        def to_predicate_method(matcher)
+          "#{matcher.to_s.sub("match_", "matches_")}?"
+        end
+      end
+    end
+  end
+end

--- a/lib/workitcop.rb
+++ b/lib/workitcop.rb
@@ -3,10 +3,15 @@
 require_relative "workitcop/inject"
 require_relative "workitcop/version"
 
+require_relative "rubocop/cop/workit/mixin/rspec_explicit_help"
+require_relative "rubocop/cop/workit/mixin/rspec_inflected_help"
+require_relative "rubocop/cop/workit/mixin/rspec_predicate_matcher_base"
+
 require_relative "rubocop/cop/workit/action_args"
 require_relative "rubocop/cop/workit/comittee_assert_schema_confirm"
 require_relative "rubocop/cop/workit/noop_rescue"
 require_relative "rubocop/cop/workit/restrict_on_send"
+require_relative "rubocop/cop/workit/rspec_capybara_predicate_matcher"
 
 module Workitcop
   PROJECT_ROOT = ::Pathname.new(__dir__).parent.expand_path.freeze

--- a/lib/workitcop/inject.rb
+++ b/lib/workitcop/inject.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rubocop"
+require "rubocop-rspec"
 
 module Workitcop
   module Inject

--- a/spec/rubocop/cop/workit/rspec_capybara_predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/workit/rspec_capybara_predicate_matcher_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Workit::RSpecCapybaraPredicateMatcher, :config do
+  let(:cop_config) do
+    {
+      "EnforcedStyle" => enforced_style,
+      "Strict" => strict,
+      "AllowedExplicitMatchers" => allowed_explicit_matchers
+    }
+  end
+  let(:allowed_explicit_matchers) { [] }
+
+  context "when `EnforcedStyle: inflected`" do
+    let(:enforced_style) { "inflected" }
+
+    shared_examples "inflected common" do
+      it "registers an offense when using predicate method" do
+        expect_offense(<<~RUBY)
+          expect(foo.matches_css?(bar: 'baz')).to be_truthy
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `match_css` matcher over `matches_css?`.
+          expect(foo.matches_selector?(bar: 'baz')).to be_falsey
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `match_selector` matcher over `matches_selector?`.
+          expect(foo.matches_style?(bar: 'baz')).not_to be_truthy
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `match_style` matcher over `matches_style?`.
+          expect(foo.matches_xpath?(bar: 'baz', foo: 'bar')).not_to be_falsey
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `match_xpath` matcher over `matches_xpath?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect(foo).to match_css(bar: 'baz')
+          expect(foo).not_to match_selector(bar: 'baz')
+          expect(foo).not_to match_style(bar: 'baz')
+          expect(foo).to match_xpath(bar: 'baz', foo: 'bar')
+        RUBY
+      end
+
+      it "does not register an offense when using non-predicate method" do
+        expect_no_offenses(<<~RUBY)
+          expect(foo).to match_css(bar: 'baz')
+          expect(foo).not_to match_selector(bar: 'baz')
+          expect(foo).not_to match_style(bar: 'baz')
+          expect(foo).to match_xpath(bar: 'baz', foo: 'bar')
+        RUBY
+      end
+    end
+
+    context "when `Strict: true`" do
+      let(:strict) { true }
+
+      include_examples "inflected common"
+
+      it "does not register an offense when strict checking boolean matcher" do
+        expect_no_offenses(<<~RUBY)
+          expect(foo.matches_css?(bar: 'baz')).to eq(true)
+          expect(foo.matches_selector?(bar: 'baz')).not_to be(false)
+        RUBY
+      end
+    end
+
+    context "when `Strict: false`" do
+      let(:strict) { false }
+
+      include_examples "inflected common"
+
+      it "registers an offense when predicate method in actual" do
+        expect_offense(<<~RUBY)
+          expect(foo.matches_css?(bar: 'baz')).to eq(true)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `match_css` matcher over `matches_css?`.
+          expect(foo.matches_style?(bar: 'baz')).not_to be(false)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `match_style` matcher over `matches_style?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect(foo).to match_css(bar: 'baz')
+          expect(foo).to match_style(bar: 'baz')
+        RUBY
+      end
+    end
+  end
+
+  context "when `EnforcedStyle: explicit`" do
+    let(:enforced_style) { "explicit" }
+
+    shared_examples "explicit" do |matcher_true, matcher_false|
+      it "registers an offense for a predicate mather" do
+        expect_offense(<<~RUBY)
+          expect(foo).to match_css(bar: 'baz')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `matches_css?` over `match_css` matcher.
+          expect(foo).not_to match_selector(bar: 'baz')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `matches_selector?` over `match_selector` matcher.
+          expect(foo).not_to match_style(bar: 'baz')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `matches_style?` over `match_style` matcher.
+          expect(foo).to match_xpath(bar: 'baz', foo: 'bar')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `matches_xpath?` over `match_xpath` matcher.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect(foo.matches_css?(bar: 'baz')).to #{matcher_true}
+          expect(foo.matches_selector?(bar: 'baz')).to #{matcher_false}
+          expect(foo.matches_style?(bar: 'baz')).to #{matcher_false}
+          expect(foo.matches_xpath?(bar: 'baz', foo: 'bar')).to #{matcher_true}
+        RUBY
+      end
+
+      context "when `AllowedExplicitMatchers: match_xpath`" do
+        let(:allowed_explicit_matchers) { ["match_xpath"] }
+
+        it "does not register an offense when " \
+           "using custom allowed explicit matchers" do
+          expect_no_offenses(<<~RUBY)
+            expect(foo).to match_xpath(bar: 'baz', foo: 'bar')
+          RUBY
+        end
+      end
+
+      it "does not register an offense when non-predicate matcher" do
+        expect_no_offenses(<<~RUBY)
+          expect(foo.matches_css?(bar: 'baz')).to #{matcher_true}
+          expect(foo.matches_selector?(bar: 'baz')).not_to #{matcher_true}
+          expect(foo.matches_style?(bar: 'baz')).to {matcher_false}
+          expect(foo.matches_xpath?(bar: 'baz', foo: 'bar')).not_to {matcher_false}
+        RUBY
+      end
+    end
+
+    context "when `Strict: true`" do
+      let(:strict) { true }
+
+      include_examples "explicit", "be(true)", "be(false)"
+    end
+
+    context "when `Strict: false`" do
+      let(:strict) { false }
+
+      include_examples "explicit", "be_truthy", "be_falsey"
+    end
+  end
+end


### PR DESCRIPTION
Prefer using predicate matcher over using predicate method directly.

Capybara defines magic matchers for predicate methods.
This cop recommends to use the predicate matcher instead of using predicate method directly.

```ruby
# @example Strict: true, EnforcedStyle: inflected (default)
# bad
expect(foo.matches_css?(bar: 'baz')).to be_truthy
expect(foo.matches_selector?(bar: 'baz')).to be_truthy
expect(foo.matches_style?(bar: 'baz')).to be_truthy
expect(foo.matches_xpath?(bar: 'baz')).to be_truthy

# good
expect(foo).to match_css(bar: 'baz')
expect(foo).to match_selector(bar: 'baz')
expect(foo).to match_style(bar: 'baz')
expect(foo).to match_xpath(bar: 'baz')

# also good - It checks "true" strictly.
expect(foo.matches_style?(bar: 'baz')).to be(true)

# @example Strict: false, EnforcedStyle: inflected
# bad
expect(foo.matches_style?(bar: 'baz')).to be_truthy
expect(foo.matches_style?(bar: 'baz')).to be(true)

# good
expect(foo).to match_style(bar: 'baz')

# @example Strict: true, EnforcedStyle: explicit
# bad
expect(foo).to match_style(bar: 'baz')

# good - the above code is rewritten to it by this cop
expect(foo.matches_style?(bar: 'baz')).to be(true)

# @example Strict: false, EnforcedStyle: explicit
# bad
expect(foo).to match_style(bar: 'baz')

# good - the above code is rewritten to it by this cop
expect(foo.matches_style?(bar: 'baz')).to be_truthy
```