### PR TITLE
Add new `Workit/RSpecMinitestAssertions` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add new `Workit/RSpecCapybaraPredicateMatcher` cop. ([@ydah])
+- Add new `Workit/RSpecMinitestAssertions` cop. ([@ydah])
 
 ## 0.3.0 - 2022-12-08
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -40,3 +40,7 @@ Workit/RSpecCapybaraPredicateMatcher:
   SupportedStyles:
     - inflected
     - explicit
+
+Workit/RSpecMinitestAssertions:
+  Description: Check if using Minitest matchers.
+  Enabled: false

--- a/lib/rubocop/cop/workit/rspec_minitest_assertions.rb
+++ b/lib/rubocop/cop/workit/rspec_minitest_assertions.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Workit
+      # Check if using Minitest matchers.
+      #
+      # @example
+      #   # bad
+      #   assert_equal(a, b)
+      #   assert_equal a, b, "must be equal"
+      #   refute_equal(a, b)
+      #
+      #   # good
+      #   expect(a).to eq(b)
+      #   expect(a).to(eq(b), "must be equal")
+      #   expect(a).not_to eq(b)
+      #
+      class RSpecMinitestAssertions < Base
+        extend AutoCorrector
+
+        MSG = "Use `%<prefer>s`."
+        RESTRICT_ON_SEND = %i[assert_equal refute_equal].freeze
+
+        # @!method minitest_assertion(node)
+        def_node_matcher :minitest_assertion, <<-PATTERN
+          (send nil? {:assert_equal :refute_equal} $_ $_ $_?)
+        PATTERN
+
+        def on_send(node)
+          minitest_assertion(node) do |expected, actual, failure_message|
+            prefer = replacement(node, expected, actual, failure_message.first)
+            add_offense(node, message: message(prefer)) do |corrector|
+              corrector.replace(node, prefer)
+            end
+          end
+        end
+
+        private
+
+        def replacement(node, expected, actual, failure_message)
+          runner = node.method?(:assert_equal) ? "to" : "not_to"
+          if failure_message.nil?
+            "expect(#{expected.source}).#{runner} eq(#{actual.source})"
+          else
+            "expect(#{expected.source}).#{runner}(eq(#{actual.source}), " \
+              "#{failure_message.source})"
+          end
+        end
+
+        def message(prefer)
+          format(MSG, prefer: prefer)
+        end
+      end
+    end
+  end
+end

--- a/lib/workitcop.rb
+++ b/lib/workitcop.rb
@@ -12,6 +12,7 @@ require_relative "rubocop/cop/workit/comittee_assert_schema_confirm"
 require_relative "rubocop/cop/workit/noop_rescue"
 require_relative "rubocop/cop/workit/restrict_on_send"
 require_relative "rubocop/cop/workit/rspec_capybara_predicate_matcher"
+require_relative "rubocop/cop/workit/rspec_minitest_assertions"
 
 module Workitcop
   PROJECT_ROOT = ::Pathname.new(__dir__).parent.expand_path.freeze

--- a/spec/rubocop/cop/workit/rspec_minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/workit/rspec_minitest_assertions_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Workit::RSpecMinitestAssertions, :config do
+  it "registers an offense when using `assert_equal`" do
+    expect_offense(<<~RUBY)
+      assert_equal(a, b)
+      ^^^^^^^^^^^^^^^^^^ Use `expect(a).to eq(b)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(a).to eq(b)
+    RUBY
+  end
+
+  it "registers an offense when using `assert_equal` with no parentheses" do
+    expect_offense(<<~RUBY)
+      assert_equal a, b
+      ^^^^^^^^^^^^^^^^^ Use `expect(a).to eq(b)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(a).to eq(b)
+    RUBY
+  end
+
+  it "registers an offense when using `assert_equal` with failure message" do
+    expect_offense(<<~RUBY)
+      assert_equal a, b, "must be equal"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(a).to(eq(b), "must be equal")`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(a).to(eq(b), "must be equal")
+    RUBY
+  end
+
+  it "registers an offense when using `assert_equal` with " \
+     "multi-line arguments" do
+    expect_offense(<<~RUBY)
+      assert_equal(a,
+      ^^^^^^^^^^^^^^^ Use `expect(a).to(eq(b), "must be equal")`.
+                    b,
+                    "must be equal")
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(a).to(eq(b), "must be equal")
+    RUBY
+  end
+
+  it "registers an offense when using `refute_equal`" do
+    expect_offense(<<~RUBY)
+      refute_equal a, b
+      ^^^^^^^^^^^^^^^^^ Use `expect(a).not_to eq(b)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(a).not_to eq(b)
+    RUBY
+  end
+
+  it "does not register an offense when using `expect(a).to eq(b)`" do
+    expect_no_offenses(<<~RUBY)
+      expect(a).to eq(b)
+    RUBY
+  end
+
+  it "does not register an offense when using `expect(a).not_to eq(b)`" do
+    expect_no_offenses(<<~RUBY)
+      expect(a).not_to eq(b)
+    RUBY
+  end
+end


### PR DESCRIPTION
This PR is add a new `Workit/RSpecMinitestAssertions` cop. 
This cop is check if using Minitest matchers.

```ruby
# bad
assert_equal(a, b)
assert_equal a, b, "must be equal"
refute_equal(a, b)

# good
expect(a).to eq(b)
expect(a).to(eq(b), "must be equal")
expect(a).not_to eq(b)
```