### PR TITLE
Add new `Workit/RSpecCapybaraMatchStyle` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add new `Workit/RSpecCapybaraPredicateMatcher` cop. ([@ydah])
 - Add new `Workit/RSpecMinitestAssertions` cop. ([@ydah])
+- Add new `Workit/RSpecCapybaraMatchStyle` cop. ([@ydah])
 
 ## 0.3.0 - 2022-12-08
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -31,6 +31,10 @@ Workit/RestrictOnSend:
     Check for `RESTRICT_ON_SEND` is defined if `on_send` or `after_send` are defined.
   Enabled: false
 
+Workit/RSpecCapybaraMatchStyle:
+  Description: Checks for usage of deprecated style methods.
+  Enabled: false
+
 Workit/RSpecCapybaraPredicateMatcher:
   Description: Prefer using predicate matcher over using predicate method directly.
   Enabled: false

--- a/lib/rubocop/cop/workit/rspec_capybara_match_style.rb
+++ b/lib/rubocop/cop/workit/rspec_capybara_match_style.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Workit
+      # Checks for usage of deprecated style methods.
+      #
+      # @example when using `assert_style`
+      #   # bad
+      #   page.find(:css, '#first').assert_style(display: 'block')
+      #
+      #   # good
+      #   page.find(:css, '#first').assert_matches_style(display: 'block')
+      #
+      # @example when using `has_style?`
+      #   # bad
+      #   expect(page.find(:css, 'first')
+      #     .has_style?(display: 'block')).to be true
+      #
+      #   # good
+      #   expect(page.find(:css, 'first')
+      #     .matches_style?(display: 'block')).to be true
+      #
+      # @example when using `have_style`
+      #   # bad
+      #   expect(page).to have_style(display: 'block')
+      #
+      #   # good
+      #   expect(page).to match_style(display: 'block')
+      #
+      class RSpecCapybaraMatchStyle < Base
+        extend AutoCorrector
+
+        MSG = "Use `%<good>s` instead of `%<bad>s`."
+        RESTRICT_ON_SEND = %i[assert_style has_style? have_style].freeze
+        PREFERRED_METHOD = {
+          "assert_style" => "assert_matches_style",
+          "has_style?" => "matches_style?",
+          "have_style" => "match_style"
+        }.freeze
+
+        def on_send(node)
+          method_node = node.loc.selector
+          add_offense(method_node) do |corrector|
+            corrector.replace(method_node,
+                              PREFERRED_METHOD[method_node.source])
+          end
+        end
+
+        private
+
+        def message(node)
+          format(MSG, good: PREFERRED_METHOD[node.source], bad: node.source)
+        end
+      end
+    end
+  end
+end

--- a/lib/workitcop.rb
+++ b/lib/workitcop.rb
@@ -11,6 +11,7 @@ require_relative "rubocop/cop/workit/action_args"
 require_relative "rubocop/cop/workit/comittee_assert_schema_confirm"
 require_relative "rubocop/cop/workit/noop_rescue"
 require_relative "rubocop/cop/workit/restrict_on_send"
+require_relative "rubocop/cop/workit/rspec_capybara_match_style"
 require_relative "rubocop/cop/workit/rspec_capybara_predicate_matcher"
 require_relative "rubocop/cop/workit/rspec_minitest_assertions"
 

--- a/spec/rubocop/cop/workit/rspec_capybara_match_style_spec.rb
+++ b/spec/rubocop/cop/workit/rspec_capybara_match_style_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Workit::RSpecCapybaraMatchStyle, :config do
+  it "registers an offense when using `assert_style`" do
+    expect_offense(<<~RUBY)
+      page.find(:css, '#first').assert_style(display: 'block')
+                                ^^^^^^^^^^^^ Use `assert_matches_style` instead of `assert_style`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      page.find(:css, '#first').assert_matches_style(display: 'block')
+    RUBY
+  end
+
+  it "registers an offense when using `has_style?`" do
+    expect_offense(<<~RUBY)
+      expect(page.find(:css, 'first')
+        .has_style?(display: 'block')).to be true
+         ^^^^^^^^^^ Use `matches_style?` instead of `has_style?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(page.find(:css, 'first')
+        .matches_style?(display: 'block')).to be true
+    RUBY
+  end
+
+  it "registers an offense when using `have_style`" do
+    expect_offense(<<~RUBY)
+      expect(page).to have_style(display: 'block')
+                      ^^^^^^^^^^ Use `match_style` instead of `have_style`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(page).to match_style(display: 'block')
+    RUBY
+  end
+
+  it "does not register an offense when using `assert_matches_style`" do
+    expect_no_offenses(<<~RUBY)
+      page.find(:css, '#first').assert_matches_style(display: 'block')
+    RUBY
+  end
+
+  it "does not register an offense when using `matches_style?`" do
+    expect_no_offenses(<<~RUBY)
+      expect(page.find(:css, 'first').matches_style?(display: 'block')).to be true
+    RUBY
+  end
+
+  it "does not register an offense when using `match_style`" do
+    expect_no_offenses(<<~RUBY)
+      expect(page).to match_style(display: 'block')
+    RUBY
+  end
+end


### PR DESCRIPTION
This PR is add new cop.
This cop considers the use of methods associated with deprecated styles to be an offense.

Check the use of the following methods:

- Capybara::Node::Matchers#has_style?
  - https://rubydoc.info/github/jnicklas/capybara/master/Capybara%2FNode%2FMatchers:has_style%3F
- Capybara::Node::Matchers#assert_style
  - https://rubydoc.info/github/jnicklas/capybara/master/Capybara%2FNode%2FMatchers:assert_style
- Capybara::RSpecMatchers#have_style
  - https://rubydoc.info/github/jnicklas/capybara/master/Capybara%2FRSpecMatchers:have_style