### PR TITLE
Fix a false negative for `Workit/ComitteeAssertSchemaConfirm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+- Fix a false negative for `Workit/ComitteeAssertSchemaConfirm`. ([@ydah])
+
 ## 0.4.1 - 2022-12-12
+
 - Add documentation. ([@ydah])
 
 ## 0.4.0 - 2022-12-12

--- a/lib/rubocop/cop/workit/comittee_assert_schema_confirm.rb
+++ b/lib/rubocop/cop/workit/comittee_assert_schema_confirm.rb
@@ -37,10 +37,18 @@ module RuboCop
           return if node.arguments?
 
           have_http_status(node.parent) do |child_node, value|
-            add_offense(node) do |corrector|
-              corrector.remove(range_by_whole_lines(child_node.parent.loc.expression, include_final_newline: true))
-              corrector.insert_after(node, "(#{value})")
-            end
+            return autocorrect(node, child_node, value)
+          end
+
+          add_offense(node)
+        end
+
+        private
+
+        def autocorrect(node, child_node, value)
+          add_offense(node) do |corrector|
+            corrector.remove(range_by_whole_lines(child_node.parent.loc.expression, include_final_newline: true))
+            corrector.insert_after(node, "(#{value})")
           end
         end
       end

--- a/spec/rubocop/cop/workit/comittee_assert_schema_confirm_spec.rb
+++ b/spec/rubocop/cop/workit/comittee_assert_schema_confirm_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Workit::ComitteeAssertSchemaConfirm, :config do
-  it "registers an offense when using `assert_schema_conform` " \
-     "with no argument" do
+  it "registers an offense and autocorrects when using `assert_schema_conform` " \
+     "with no argument and `have_http_status`" do
     expect_offense(<<~RUBY)
       it 'something' do
         subject
@@ -22,7 +22,21 @@ RSpec.describe RuboCop::Cop::Workit::ComitteeAssertSchemaConfirm, :config do
     RUBY
   end
 
-  it "does not register an offense when using `assert_schema_conform` " \
+  it "registers an offense when using `assert_schema_conform` " \
+     "with no argument" do
+    expect_offense(<<~RUBY)
+      it 'something' do
+        subject
+        do_something
+        assert_schema_conform
+        ^^^^^^^^^^^^^^^^^^^^^ Pass expected response status code to check it against the corresponding schema explicitly.
+      end
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it "does not register an offense and autocorrects when using `assert_schema_conform` " \
      "with http status code" do
     expect_no_offenses(<<~RUBY)
       it 'something' do
@@ -32,7 +46,7 @@ RSpec.describe RuboCop::Cop::Workit::ComitteeAssertSchemaConfirm, :config do
     RUBY
   end
 
-  it "registers an offense when using `assert_response_schema_confirm` " \
+  it "registers an offense and autocorrects when using `assert_response_schema_confirm` " \
      "with no argument" do
     expect_offense(<<~RUBY)
       it 'something' do


### PR DESCRIPTION
This PR is fix a false negative for `Workit/ComitteeAssertSchemaConfirm`.

```ruby
it 'something' do
  subject
  do_something
  assert_schema_conform
end
```